### PR TITLE
Fix getVersion to deal with sbt's frivolous formatting.

### DIFF
--- a/getVersion.sh
+++ b/getVersion.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 # As of 5/3/2017, we include the date in the sbt version so there's no need to add it here.
-sbt version | gawk -e '/^\[info\] [[:digit:]]+\.[[:digit:]]/ { print "v" $2 }'
+# This is very brittle, depending, as it does, on sbt's formatting.
+# We assume that in the case of multiple subprojects, the version is determined
+#  by the root project, whose version is given by the line following:
+#  [info] version
+sbt version | gawk -e 'BEGIN{m=1}' -e '/^\[info\] version$/{m=1}' -e 'm==1 && $1 ~ /^\[info\]/ && $2 ~ /[[:digit:]]+\.[[:digit:]]/ { print "v" $2; m=0 }' -e '/ \/ version$/{m=0}'


### PR DESCRIPTION
`sbt` uses a different format to output the version for a multi-project, with no apparent way to obtain just the top level project version. Deal with it.