### PR TITLE
Add default branches for submodules to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,36 @@
 [submodule "chisel3"]
 	path = chisel3
 	url = https://github.com/freechipsproject/chisel3.git
+	branch = master
 [submodule "chisel-testers"]
 	path = chisel-testers
 	url = https://github.com/freechipsproject/chisel-testers.git
+	branch = master
 [submodule "firrtl"]
 	path = firrtl
 	url = https://github.com/freechipsproject/firrtl.git
+	branch = master
 [submodule "firrtl-interpreter"]
 	path = firrtl-interpreter
 	url = https://github.com/freechipsproject/firrtl-interpreter.git
+	branch = master
 [submodule "dsptools"]
 	path = dsptools
 	url = git@github.com:ucb-bar/dsptools.git
+	branch = master
 [submodule "treadle"]
 	path = treadle
 	url = https://github.com/freechipsproject/treadle.git
+	branch = master
 [submodule "diagrammer"]
 	path = diagrammer
 	url = https://github.com/freechipsproject/diagrammer
+	branch = master
 [submodule "rocket-chip"]
 	path = rocket-chip
 	url = https://github.com/freechipsproject/rocket-chip.git
+	branch = master
 [submodule "testchipip"]
 	path = testchipip
 	url = https://github.com/ucb-bar/testchipip.git
+	branch = master


### PR DESCRIPTION
This simplifies updates. Following this, one can use:
```bash
git submodule foreach 'git checkout $(git config -f $toplevel/.gitmodules submodule.$name.branch || echo master)'
```
to ensure one is working on the correct branch (as opposed to a detached head).

This doesn't help with `master` or `release` (where every submodule is on the same branch), but it does help with `3.2.x` where every submodule may be on a different branch.
